### PR TITLE
rtg: .com to .org

### DIFF
--- a/blocked_domains.acl
+++ b/blocked_domains.acl
@@ -30,7 +30,7 @@
 .monerominer.rocks
 .winxmr.net
 .semway.me
-.runthegauntlet.com
+.runthegauntlet.org
 .seegore.com
 .goregrish.com
 .furogore.com


### PR DESCRIPTION
.com redirects to http://rtgmanagement.co.uk/domains.html
.org is the actual site